### PR TITLE
Add iOS Chrome detection and explicit Safari messaging

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -26,6 +26,7 @@ export default function DashboardLayout({
   const [isStandalone, setIsStandalone] = useState(false)
   const [showInstallBanner, setShowInstallBanner] = useState(false)
   const [bannerDismissed, setBannerDismissed] = useState(false)
+  const [isIOSChrome, setIsIOSChrome] = useState(false)
   const router = useRouter()
   const supabase = createClient()
 
@@ -73,7 +74,15 @@ export default function DashboardLayout({
       setIsStandalone(isStandaloneMode)
     }
 
+    // Detect iOS Chrome
+    const checkIOSChrome = () => {
+      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
+      const isChrome = /CriOS/.test(navigator.userAgent)
+      setIsIOSChrome(isIOS && isChrome)
+    }
+
     checkStandalone()
+    checkIOSChrome()
 
     const handleBeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
       e.preventDefault()
@@ -169,10 +178,10 @@ export default function DashboardLayout({
                 <Smartphone className="h-5 w-5 text-blue-600 dark:text-blue-400" />
                 <div>
                   <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
-                    Install GlucoseMojo for quick access
+                    {isIOSChrome ? 'Use Safari to install GlucoseMojo' : 'Install GlucoseMojo for quick access'}
                   </p>
                   <p className="text-xs text-blue-700 dark:text-blue-300">
-                    Add to your home screen for faster glucose tracking
+                    {isIOSChrome ? 'Chrome on iOS cannot install PWAs - open in Safari' : 'Add to your home screen for faster glucose tracking'}
                   </p>
                 </div>
               </div>
@@ -182,7 +191,7 @@ export default function DashboardLayout({
                   disabled={!deferredPrompt}
                   className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
                 >
-                  Install
+                  {isIOSChrome ? 'Use Safari' : 'Install'}
                 </button>
                 <button
                   onClick={dismissBanner}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -17,6 +17,7 @@ export default function HomePage() {
   const [loading, setLoading] = useState(true)
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null)
   const [isStandalone, setIsStandalone] = useState(false)
+  const [isIOSChrome, setIsIOSChrome] = useState(false)
   const router = useRouter()
   const supabase = createClient()
 
@@ -51,7 +52,15 @@ export default function HomePage() {
       setIsStandalone(isStandaloneMode)
     }
 
+    // Detect iOS Chrome
+    const checkIOSChrome = () => {
+      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
+      const isChrome = /CriOS/.test(navigator.userAgent)
+      setIsIOSChrome(isIOS && isChrome)
+    }
+
     checkStandalone()
+    checkIOSChrome()
 
     const handleBeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
       e.preventDefault()
@@ -126,7 +135,7 @@ export default function HomePage() {
                 className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white px-6 py-3 rounded-lg font-semibold transition-colors shadow-lg"
               >
                 <Smartphone className="h-5 w-5" />
-                {deferredPrompt ? 'Install App' : 'Install Available in Browser Menu'}
+                {deferredPrompt ? 'Install App' : isIOSChrome ? 'Use Safari to Install on iOS' : 'Install Available in Browser Menu'}
               </button>
             </div>
           )}


### PR DESCRIPTION
- Detect iOS Chrome users who cannot install PWAs
- Show clear "Use Safari to Install on iOS" messaging
- Update both homepage and dashboard install buttons
- Provide explicit guidance instead of generic browser menu text

🤖 Generated with [Claude Code](https://claude.ai/code)